### PR TITLE
Breaking Changes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.harrys.hyppo"
 
 name := "source-api"
 
-version := "0.4.0-SNAPSHOT"
+version := "0.4.0"
 
 sonatypeProfileName := "com.harrys"
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.harrys.hyppo"
 
 name := "source-api"
 
-version := "0.3.0"
+version := "0.4.0-SNAPSHOT"
 
 sonatypeProfileName := "com.harrys"
 

--- a/src/main/java/com/harrys/hyppo/source/api/DataIntegration.java
+++ b/src/main/java/com/harrys/hyppo/source/api/DataIntegration.java
@@ -5,7 +5,7 @@ import com.harrys.hyppo.source.api.model.DataIngestionTask;
 import com.harrys.hyppo.source.api.task.ProcessedDataPersister;
 import com.harrys.hyppo.source.api.model.DataIngestionJob;
 import com.harrys.hyppo.source.api.model.IngestionSource;
-import com.harrys.hyppo.source.api.task.TaskCreator;
+import com.harrys.hyppo.source.api.task.IngestionTaskCreator;
 import org.apache.avro.specific.SpecificRecord;
 
 /**
@@ -21,8 +21,8 @@ public interface DataIntegration<T extends SpecificRecord> {
 
     ValidationResult validateTaskArguments(final DataIngestionTask task);
 
-    TaskCreator newIngestionTaskCreator();
+    IngestionTaskCreator newIngestionTaskCreator();
 
-    ProcessedDataPersister<T> newDataPersister();
+    ProcessedDataPersister<T> newProcessedDataPersister();
 
 }

--- a/src/main/java/com/harrys/hyppo/source/api/PersistingSemantics.java
+++ b/src/main/java/com/harrys/hyppo/source/api/PersistingSemantics.java
@@ -1,5 +1,8 @@
 package com.harrys.hyppo.source.api;
 
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonValue;
+
 /**
  * Created by jpetty on 10/20/15.
  */
@@ -16,4 +19,24 @@ public enum PersistingSemantics {
      * therefore not appropriate to respond to a failure by retrying.
      */
     Idempotent;
+
+
+    /**
+     * @return This method returns the same thing as {@link PersistingSemantics#name()} and is only defined so that the
+     * {@link JsonValue} annotation can be attached to it.
+     */
+    @JsonValue
+    public final String getJsonName(){
+        return this.name();
+    }
+
+    @JsonCreator
+    public static final PersistingSemantics fromString(final String name) {
+        for (final PersistingSemantics check : PersistingSemantics.values()){
+            if (check.name().equalsIgnoreCase(name)){
+                return check;
+            }
+        }
+        throw new IllegalArgumentException("Unknown " + PersistingSemantics.class.getName() + " type: " + name);
+    }
 }

--- a/src/main/java/com/harrys/hyppo/source/api/model/ConfigToJson.java
+++ b/src/main/java/com/harrys/hyppo/source/api/model/ConfigToJson.java
@@ -18,12 +18,16 @@ import java.io.IOException;
 public final class ConfigToJson {
 
     public static final class Serializer extends JsonSerializer<Config> {
-        private static final ConfigRenderOptions renderOptions = ConfigRenderOptions.concise().setJson(true);
+        private static final ConfigRenderOptions renderOptions   = ConfigRenderOptions.concise().setJson(true);
+        private static final ConfigResolveOptions resolveOptions = ConfigResolveOptions.noSystem().setAllowUnresolved(false);
 
         public Serializer(){ }
 
         @Override
         public final void serialize(Config value, JsonGenerator jgen, SerializerProvider provider) throws IOException, JsonProcessingException {
+            if (!value.isResolved()){
+                value = value.resolve(resolveOptions);
+            }
             final String jsonObject = value.root().render(renderOptions);
             jgen.writeRawValue(jsonObject);
         }

--- a/src/main/java/com/harrys/hyppo/source/api/task/CreateIngestionTasks.java
+++ b/src/main/java/com/harrys/hyppo/source/api/task/CreateIngestionTasks.java
@@ -2,6 +2,7 @@ package com.harrys.hyppo.source.api.task;
 
 import com.harrys.hyppo.source.api.model.TaskBuilder;
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
 import com.harrys.hyppo.source.api.model.DataIngestionJob;
@@ -43,7 +44,12 @@ public final class CreateIngestionTasks {
     }
 
     public final CreateIngestionTasks createTaskWithArgs(final Map<String, Object> arguments){
-        final Config value = ConfigValueFactory.fromMap(arguments).toConfig();
+        final Config value;
+        try {
+            value = ConfigValueFactory.fromMap(arguments).toConfig();
+        } catch (ConfigException ce) {
+            throw new IllegalArgumentException("Can't create a Config object from arguments!", ce);
+        }
         return this.createTaskWithArgs(value);
     }
 

--- a/src/main/java/com/harrys/hyppo/source/api/task/CreateIngestionTasks.java
+++ b/src/main/java/com/harrys/hyppo/source/api/task/CreateIngestionTasks.java
@@ -12,7 +12,7 @@ import java.util.Map;
 /**
  * Created by jpetty on 7/17/15.
  */
-public final class CreateTasksForJob {
+public final class CreateIngestionTasks {
 
     private static final Config sharedEmptyConfig = ConfigFactory.empty();
 
@@ -20,7 +20,7 @@ public final class CreateTasksForJob {
 
     private final TaskBuilder builder;
 
-    public CreateTasksForJob(final DataIngestionJob job){
+    public CreateIngestionTasks(final DataIngestionJob job){
         this.job      = job;
         this.builder  = new TaskBuilder();
     }
@@ -37,17 +37,17 @@ public final class CreateTasksForJob {
         return this.builder;
     }
 
-    public final CreateTasksForJob createTaskWithArgs(final Config arguments){
+    public final CreateIngestionTasks createTaskWithArgs(final Config arguments){
         this.builder.addTask(arguments);
         return this;
     }
 
-    public final CreateTasksForJob createTaskWithArgs(final Map<String, Object> arguments){
+    public final CreateIngestionTasks createTaskWithArgs(final Map<String, Object> arguments){
         final Config value = ConfigValueFactory.fromMap(arguments).toConfig();
         return this.createTaskWithArgs(value);
     }
 
-    public final CreateTasksForJob createTaskWithoutArgs(){
+    public final CreateIngestionTasks createTaskWithoutArgs(){
         return this.createTaskWithArgs(sharedEmptyConfig);
     }
 }

--- a/src/main/java/com/harrys/hyppo/source/api/task/IngestionTaskCreator.java
+++ b/src/main/java/com/harrys/hyppo/source/api/task/IngestionTaskCreator.java
@@ -1,0 +1,8 @@
+package com.harrys.hyppo.source.api.task;
+
+/**
+ * Created by jpetty on 7/17/15.
+ */
+public interface IngestionTaskCreator {
+    void createIngestionTasks(CreateIngestionTasks operation) throws Exception;
+}

--- a/src/main/java/com/harrys/hyppo/source/api/task/ProcessedDataPersister.java
+++ b/src/main/java/com/harrys/hyppo/source/api/task/ProcessedDataPersister.java
@@ -14,7 +14,7 @@ public interface ProcessedDataPersister<T extends SpecificRecord> {
      * after a failure or restart.
      * @return The {@link PersistingSemantics} enum value appropriate for this persister implementation.
      */
-    default PersistingSemantics retrySemantics(){
+    default PersistingSemantics semantics(){
         return PersistingSemantics.Default;
     }
 }

--- a/src/main/java/com/harrys/hyppo/source/api/task/TaskCreator.java
+++ b/src/main/java/com/harrys/hyppo/source/api/task/TaskCreator.java
@@ -1,8 +1,0 @@
-package com.harrys.hyppo.source.api.task;
-
-/**
- * Created by jpetty on 7/17/15.
- */
-public interface TaskCreator {
-    void createTasks(CreateTasksForJob operation) throws Exception;
-}


### PR DESCRIPTION
Sorry, this time around we introduced the notion of PersitenceSemantics for the processed data persister and then standardized all the naming conventions to keep things consistent.